### PR TITLE
Increase customization and number of images

### DIFF
--- a/lib/camera_file.dart
+++ b/lib/camera_file.dart
@@ -170,6 +170,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
                                 ? ScaleTransition(
                                     scale: scaleAnimation,
                                     child: GestureDetector(
+                                      behavior: HitTestBehavior.translucent,
                                       onTap: () {
                                         Navigator.push(
                                             context,
@@ -182,34 +183,42 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
                                                           "",
                                                         )));
                                       },
-                                      child: Stack(
-                                        clipBehavior: Clip.none,
-                                        children: [
-                                          Image.file(
-                                            File(
-                                              imageFiles[index].path,
-                                            ),
-                                            height: 90,
-                                            width: 60,
-                                          ),
-                                          Positioned(
-                                            top: -17,
-                                            right: -15,
-                                            child: GestureDetector(
-                                              onTap: () {
-                                                setState(() {
-                                                  removeImage();
-                                                  widget.onCapture?.call(imageFiles.length);
-                                                });
-                                              },
-                                              child: (widget.removeImageIcon != null) ? widget.removeImageIcon : const Icon(
-                                                Icons.cancel,
-                                                color: Colors.white,
-                                                size: 40,
+                                      child: Container(
+                                        margin: EdgeInsets.only(bottom: widget.bottomLeftSize != null ? widget.bottomLeftSize!/2 : 40, left: 15),
+                                        width: 77,
+                                        height: 105,
+                                        child: Stack(
+                                          clipBehavior: Clip.none,
+                                          children: [
+                                            Padding(
+                                              padding: EdgeInsets.only(top: 15),
+                                              child: Image.file(
+                                                File(
+                                                  imageFiles[index].path,
+                                                ),
+                                                height: 90 ,
+                                                width: 60,
                                               ),
                                             ),
-                                          )
-                                        ],
+                                            Positioned(
+                                              top: 0,
+                                              right: 0,
+                                              child: GestureDetector(
+                                                onTap: () {
+                                                  setState(() {
+                                                    removeImage();
+                                                    widget.onCapture?.call(imageFiles.length);
+                                                  });
+                                                },
+                                                child: (widget.removeImageIcon != null) ? widget.removeImageIcon : const Icon(
+                                                  Icons.cancel,
+                                                  color: Colors.white,
+                                                  size: 40,
+                                                ),
+                                              ),
+                                            ),
+                                          ],
+                                        ),
                                       ),
                                     ),
                                   )
@@ -442,6 +451,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
               : const SizedBox(width: 8.0,)
           ],
         ),
+        leadingWidth: double.infinity,
         elevation: 0,
         backgroundColor: Colors.transparent,
       ),

--- a/lib/camera_file.dart
+++ b/lib/camera_file.dart
@@ -8,6 +8,7 @@ import 'package:multiple_image_camera/image_preview.dart';
 class CameraFile extends StatefulWidget {
   final Widget? doneButton;
   final Widget? bottomLeftButton;
+  final List<Widget>? centerWidgets;
   final ButtonStyle? backButtonStyle;
   final Icon? removeImageIcon;
   final Icon? cancelIcon;
@@ -18,6 +19,7 @@ class CameraFile extends StatefulWidget {
     super.key,
     this.doneButton,
     this.bottomLeftButton,
+    this.centerWidgets, 
     this.bottomLeftSize,
     this.backButtonStyle,
     this.removeImageIcon,
@@ -408,6 +410,11 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
               ),
               onPressed: () => Navigator.pop(context, imageList),
             ),
+            Flexible(child: Container()),
+            Row(
+              children: widget.centerWidgets != null ? widget.centerWidgets! : [],
+            ),
+            Flexible(child: Container()),
             (widget.flashIcon == true) ? IconButton(
               iconSize: 50,
               icon: Icon(

--- a/lib/camera_file.dart
+++ b/lib/camera_file.dart
@@ -42,7 +42,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
   List<MediaModel> imageList = <MediaModel>[];
   late int _currIndex;
   late Animation<double> animation;
-  late AnimationController? _animationController;
+  AnimationController? _animationController;
   late Animation<double> scaleAnimation;
 
   FlashMode flashMode = FlashMode.off;
@@ -90,9 +90,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
   }
 
   removeImage() {
-    setState(() {
       imageFiles.removeLast();
-    });
   }
 
   Widget? _animatedButton({Widget? customContent}) {
@@ -342,7 +340,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
                     ),
                   ],
                 ),
-              )
+              ),
             ])));
   }
 

--- a/lib/camera_file.dart
+++ b/lib/camera_file.dart
@@ -7,15 +7,17 @@ import 'package:multiple_image_camera/image_preview.dart';
 
 class CameraFile extends StatefulWidget {
   final Widget? doneButton;
-  final Widget? rotateCameraIcon;
+  final Widget? bottomLeftButton;
   final ButtonStyle? backButtonStyle;
   final Icon? cancelIcon;
   final int? maxPictures;
   final bool? flashIcon;
+  final double? bottomLeftSize;
   const CameraFile({
     super.key,
     this.doneButton,
-    this.rotateCameraIcon,
+    this.bottomLeftButton,
+    this.bottomLeftSize,
     this.backButtonStyle,
     this.cancelIcon,
     this.maxPictures,
@@ -237,15 +239,17 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
               Positioned(
                 right:
                     MediaQuery.of(context).orientation == Orientation.portrait
-                        ? 340
+                        ? widget.bottomLeftSize == null ? 340 : MediaQuery.of(context).size.width - widget.bottomLeftSize!
                         : null,
+                top: widget.bottomLeftSize == null ? null : MediaQuery.of(context).size.height - widget.bottomLeftSize!,
                 bottom: 0,
                 left: 0,
                 child: IconButton(
-                  iconSize: 40,
-                  icon: (widget.rotateCameraIcon != null) ? widget.rotateCameraIcon! : const Icon(
+                  iconSize: widget.bottomLeftSize ?? 40,
+                  icon: (widget.bottomLeftButton != null) ? widget.bottomLeftButton! : Icon(
                     Icons.camera_front,
                     color: Colors.white,
+                    size: widget.bottomLeftSize,
                   ),
                   onPressed: _onCameraSwitch,
                 ),

--- a/lib/camera_file.dart
+++ b/lib/camera_file.dart
@@ -11,10 +11,10 @@ class CameraFile extends StatefulWidget {
   final List<Widget>? centerWidgets;
   final ButtonStyle? backButtonStyle;
   final Icon? removeImageIcon;
-  final Icon? cancelIcon;
   final int? maxPictures;
   final bool? flashIcon;
   final double? bottomLeftSize;
+  final Function(int)? onCapture;
   const CameraFile({
     super.key,
     this.doneButton,
@@ -23,9 +23,9 @@ class CameraFile extends StatefulWidget {
     this.bottomLeftSize,
     this.backButtonStyle,
     this.removeImageIcon,
-    this.cancelIcon,
     this.maxPictures,
     this.flashIcon,
+    this.onCapture,
   });
 
   @override
@@ -85,9 +85,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
   }
 
   addImages(XFile image) {
-    setState(() {
-      imageFiles.add(image);
-    });
+    imageFiles.add(image);
     hasCapturedAllImages();
   }
 
@@ -201,6 +199,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
                                               onTap: () {
                                                 setState(() {
                                                   removeImage();
+                                                  widget.onCapture?.call(imageFiles.length);
                                                 });
                                               },
                                               child: (widget.removeImageIcon != null) ? widget.removeImageIcon : const Icon(
@@ -377,6 +376,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
       setState(() {
         addImages(image);
         HapticFeedback.lightImpact();
+        widget.onCapture?.call(imageFiles.length);
       });
     } on CameraException {
       return null;

--- a/lib/camera_file.dart
+++ b/lib/camera_file.dart
@@ -9,6 +9,7 @@ class CameraFile extends StatefulWidget {
   final Widget? doneButton;
   final Widget? bottomLeftButton;
   final ButtonStyle? backButtonStyle;
+  final Icon? removeImageIcon;
   final Icon? cancelIcon;
   final int? maxPictures;
   final bool? flashIcon;
@@ -19,6 +20,7 @@ class CameraFile extends StatefulWidget {
     this.bottomLeftButton,
     this.bottomLeftSize,
     this.backButtonStyle,
+    this.removeImageIcon,
     this.cancelIcon,
     this.maxPictures,
     this.flashIcon,
@@ -199,10 +201,10 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
                                                   removeImage();
                                                 });
                                               },
-                                              child: (widget.cancelIcon != null) ? widget.cancelIcon : const Icon(
+                                              child: (widget.removeImageIcon != null) ? widget.removeImageIcon : const Icon(
                                                 Icons.cancel,
                                                 color: Colors.white,
-                                                size: 35,
+                                                size: 40,
                                               ),
                                             ),
                                           )

--- a/lib/camera_file.dart
+++ b/lib/camera_file.dart
@@ -34,8 +34,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
   List<MediaModel> imageList = <MediaModel>[];
   late int _currIndex;
   late Animation<double> animation;
-  late AnimationController _animationController;
-  late AnimationController controller;
+  late AnimationController? _animationController;
   late Animation<double> scaleAnimation;
 
   hasCapturesAllImages(){
@@ -48,7 +47,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
         imageList.add(
             MediaModel.blob(file, "", file.readAsBytesSync()));
       }
-      _animationController.stop();
+      _animationController?.stop();
       Navigator.pop(context, imageList);
     }
   }
@@ -59,9 +58,9 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
           vsync: this, duration: const Duration(milliseconds: 1500));
       animation = Tween<double>(begin: 400, end: 1).animate(scaleAnimation =
           CurvedAnimation(
-              parent: _animationController, curve: Curves.elasticOut))
+              parent: _animationController!, curve: Curves.elasticOut))
         ..addListener(() {});
-      _animationController.forward();
+      _animationController!.forward();
       HapticFeedback.lightImpact();
     },);
   }
@@ -409,11 +408,8 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
 
   @override
   void dispose() {
-    if (_controller != null) {
-      _controller!.dispose();
-    } else {
-      _animationController.dispose();
-    }
+    _controller?.dispose();
+    _animationController?.dispose();
 
     super.dispose();
   }

--- a/lib/camera_file.dart
+++ b/lib/camera_file.dart
@@ -90,7 +90,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
   }
 
   removeImage() {
-      imageFiles.removeLast();
+    imageFiles.removeLast();
   }
 
   Widget? _animatedButton({Widget? customContent}) {

--- a/lib/camera_file.dart
+++ b/lib/camera_file.dart
@@ -37,7 +37,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
   late AnimationController? _animationController;
   late Animation<double> scaleAnimation;
 
-  hasCapturesAllImages(){
+  hasCapturedAllImages(){
     if (widget.maxPictures == null){
       return null;
     }
@@ -69,7 +69,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
     setState(() {
       imageFiles.add(image);
     });
-    hasCapturesAllImages();
+    hasCapturedAllImages();
   }
 
   removeImage() {

--- a/lib/multiple_image_camera.dart
+++ b/lib/multiple_image_camera.dart
@@ -6,7 +6,11 @@ import 'package:multiple_image_camera/camera_file.dart';
 class MultipleImageCamera {
   static Future<List<MediaModel>> capture({
     required BuildContext context,
-    Widget? customDoneButton
+    Widget? customDoneButton,
+    Widget? rotateCameraIcon,
+    ButtonStyle? backButtonStyle,
+    Icon? cancelIcon,
+    int? maxPictures,
   }) async {
     List<MediaModel> images = [];
     try {
@@ -15,6 +19,10 @@ class MultipleImageCamera {
           MaterialPageRoute(
               builder: (BuildContext context) =>  CameraFile(
                 customButton: customDoneButton,
+                rotateCameraIcon: rotateCameraIcon,
+                backButtonStyle: backButtonStyle,
+                cancelIcon: cancelIcon,
+                maxPictures: maxPictures,
               )));
     // ignore: empty_catches
     } catch (e) {

--- a/lib/multiple_image_camera.dart
+++ b/lib/multiple_image_camera.dart
@@ -6,11 +6,15 @@ import 'package:multiple_image_camera/camera_file.dart';
 class MultipleImageCamera {
   static Future<List<MediaModel>> capture({
     required BuildContext context,
-    Widget? customDoneButton,
-    Widget? rotateCameraIcon,
+    Widget? doneButton,
+    Widget? bottomLeftButton,
+    List<Widget>? centerWidgets,
     ButtonStyle? backButtonStyle,
-    Icon? cancelIcon,
+    Icon? removeImageIcon,
     int? maxPictures,
+    double? bottomLeftSize,
+    bool? flashIcon,
+    Function(int)? onCapture,
   }) async {
     List<MediaModel> images = [];
     try {
@@ -18,11 +22,15 @@ class MultipleImageCamera {
           context,
           MaterialPageRoute(
               builder: (BuildContext context) =>  CameraFile(
-                customButton: customDoneButton,
-                rotateCameraIcon: rotateCameraIcon,
+                doneButton: doneButton,
+                bottomLeftButton: bottomLeftButton,
+                centerWidgets: centerWidgets,
+                bottomLeftSize: bottomLeftSize,
                 backButtonStyle: backButtonStyle,
-                cancelIcon: cancelIcon,
+                removeImageIcon: removeImageIcon,
                 maxPictures: maxPictures,
+                flashIcon: flashIcon,
+                onCapture: onCapture,
               )));
     // ignore: empty_catches
     } catch (e) {


### PR DESCRIPTION
Variables added to give developers more customization of the icons when taking pictures.  Icons effected are the cancel icon on the image, rotate camera icon and the back button icon. Another variable "maxPictures" allows for an optional argument to limit the number of images to be taken by the end user.  This in the case where the app needs an exact number of images.  Back button added to the app bar and given an on pressed method to keep capture from returning null.