### PR TITLE
BUGFIX: always dispose animation controller

### DIFF
--- a/lib/camera_file.dart
+++ b/lib/camera_file.dart
@@ -24,14 +24,11 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
   late int _currIndex;
   late Animation<double> animation;
   late AnimationController _animationController;
-  late AnimationController controller;
   late Animation<double> scaleAnimation;
 
   addImages(XFile image) {
     setState(() {
       imageFiles.add(image);
-      _animationController = AnimationController(
-          vsync: this, duration: const Duration(milliseconds: 1500));
       animation = Tween<double>(begin: 400, end: 1).animate(scaleAnimation =
           CurvedAnimation(
               parent: _animationController, curve: Curves.elasticOut))
@@ -85,6 +82,7 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
 
   @override
   void initState() {
+    _animationController = AnimationController(vsync: this, duration: const Duration(milliseconds: 1500));
     _initCamera();
     _currIndex = 0;
 
@@ -367,12 +365,8 @@ class _CameraFileState extends State<CameraFile> with TickerProviderStateMixin {
 
   @override
   void dispose() {
-    if (_controller != null) {
-      _controller!.dispose();
-    } else {
-      _animationController.dispose();
-    }
-
+    _controller?.dispose();
+    _animationController.dispose();
     super.dispose();
   }
 }


### PR DESCRIPTION
We started using your package and noticed that `_CameraFileState` doesn't properly dispose of `_animationController`. This was causing our app to crash with a "red screen of death" whenever we utilized `MultipleImageCamera.capture` multiple times. (I.e. open camera, take a picture, do something, go back, open another camera, take a picture...) Thanks to the code in this PR the crashes are gone 🎉

I have attached a screen recording that shows a typical sequence of unhandled errors that leads to the "red screen of death". The errors include:
- `FlutterError: _CameraFileState was disposed with an active Ticker.`
- `_AssertionError '_elements.contains(element': is not true`
- `FlutterError duplicate GlobalKeys detected in widget tree.`

We'd be honored if you were to use this code to create a new release for https://pub.dev/packages/multiple_image_camera.

https://github.com/user-attachments/assets/0be6cbc9-6662-45f5-8bbb-25051977b75e